### PR TITLE
Workaround for sbt-jni bug README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Occasionally it might happen that multiple versions of Java are
 installed. To enforce to correct version of Jave, overwrite
 `JAVA_HOME` and `PATH`:
 
-    > export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
+    > export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
     > export PATH=$JAVA_HOME/bin:$PATH
     > sbt compile
     > sbt nativeCompile


### PR DESCRIPTION
The nativeCompile command provided by sbt-jni currently ignores the -java-home command line switch
(see: https://github.com/jodersky/sbt-jni/issues/14). The README now suggests the appropriate exports.
