### PR TITLE
Native Image using Graal

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,6 +102,20 @@ Proceed as follows to build Leo-III from source:
    The default install destination is `$HOME/bin`. This will copy the `leo3` executable there.
    The install destination can be modified using the `DESTDIR` modifier.
 
+### Native Image
+
+In order to create a native image, please install [GraalVM](https://www.graalvm.org/docs/getting-started/) and
+follow the instructions found there.
+
+Also make sure to install `zlib` and `libc` in the static linked equivalents for your operating system of choice.
+
+After that feel free to execute
+
+      make native
+
+In the root directory which will produce a native binary called leo3-bin in the bin folder.
+
+
 ### Using nix
 
 We support using [Nix](https://nixos.org) for creating a reliable and reproducible execution environment for Leo-III. The source distribution contains a `.nix` file that can be used to run Leo-III within a `nix` shell (see `contrib/default.nix`).

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CONTRIB=./contrib
 default: all
 all: TreeLimitedRun leo3
 static: TreeLimitedRunStatic leo3
+native: leo3
 
 TreeLimitedRun: $(CONTRIB)/TreeLimitedRun.c
 		@echo Compiling auxiliary scripts ...
@@ -32,3 +33,13 @@ clean:
 		rm -rf ./target/
 		rm -rf ./bin/
 
+native:
+		@echo Creating native Leo-III image with graalvm
+		native-image -jar bin/leo3.jar \
+			-H:+ReportExceptionStackTraces \
+			-H:Name="leo3-bin" \
+			--delay-class-initialization-to-runtime=leo.modules.modes.Normalization\$$ \
+			-H:ReflectionConfigurationFiles=${CONTRIB}/graalvm/reflectconfig \
+			-O2 \
+			--static
+		mv leo3-bin bin/leo3-bin

--- a/contrib/graalvm/reflectconfig
+++ b/contrib/graalvm/reflectconfig
@@ -1,0 +1,11 @@
+[
+  {
+    "name" : "parser.ThfAstGen",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  }
+]


### PR DESCRIPTION
Hi all,

i have used the GraalVM tooling in order to create a native binary.
Preliminary tests suggest a decent speed up. For instance on sur_cantor.p from the test suite:

- Nonnative:  % SZS status Theorem for ../src/test/resources/problems/sur_cantor.p : 1721 ms resp. 1128 ms w/o parsing
- Native: % SZS status Theorem for ../src/test/resources/problems/sur_cantor.p : 225 ms resp. 195 ms w/o parsing

The build  instructions can be found in the INSTALL.md. 

In case of any questions or comments, feel free to reach out.

Best regards,
Marco